### PR TITLE
Switch from deprecated ReactDOM.render to ReactDOM.createRoot.render …

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,15 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
 import 'bootstrap/dist/css/bootstrap.min.css';
 
-ReactDOM.render(
-    <React.StrictMode>
-        <App/>
-    </React.StrictMode>,
-    document.getElementById('root')
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
 );
 const styleLink = document.createElement("link");
 styleLink.rel = "stylesheet";


### PR DESCRIPTION
ReactDOM.render is deprecated and this error prevents actual use of React 18, and downgrades to React 17 AFAICT from the errors.