### PR TITLE
added clustering support for markers. minor fix for the positioning o…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-leaflet": "^4.2.0",
+        "react-leaflet-cluster": "^2.1.0",
         "react-router-dom": "^5.2.0",
         "react-scripts": "^5.0.1",
         "semantic-ui-react": "^2.1.4",
@@ -13313,6 +13314,14 @@
       "resolved": "https://packages.atlassian.com/api/npm/npm-remote/leaflet/-/leaflet-1.9.3.tgz",
       "integrity": "sha512-iB2cR9vAkDOu5l3HAay2obcUHZ7xwUBBjph8+PGtmW/2lYhbLizWtG7nTeYht36WfOslixQF9D/uSIzhZgGMfQ=="
     },
+    "node_modules/leaflet.markercluster": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/leaflet.markercluster/-/leaflet.markercluster-1.5.3.tgz",
+      "integrity": "sha512-vPTw/Bndq7eQHjLBVlWpnGeLa3t+3zGiuM7fJwCkiMFq+nmRuG3RI3f7f4N4TDX7T4NpbAXpR2+NTRSEGfCSeA==",
+      "peerDependencies": {
+        "leaflet": "^1.3.1"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://packages.atlassian.com/api/npm/npm-remote/leven/-/leven-3.1.0.tgz",
@@ -15777,6 +15786,20 @@
         "leaflet": "^1.9.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/react-leaflet-cluster": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet-cluster/-/react-leaflet-cluster-2.1.0.tgz",
+      "integrity": "sha512-16X7XQpRThQFC4PH4OpXHimGg19ouWmjxjtpxOeBKpvERSvIRqTx7fvhTwkEPNMFTQ8zTfddz6fRTUmUEQul7g==",
+      "dependencies": {
+        "leaflet.markercluster": "^1.5.3"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.8.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0",
+        "react-leaflet": "^4.0.0"
       }
     },
     "node_modules/react-popper": {
@@ -28962,6 +28985,12 @@
       "resolved": "https://packages.atlassian.com/api/npm/npm-remote/leaflet/-/leaflet-1.9.3.tgz",
       "integrity": "sha512-iB2cR9vAkDOu5l3HAay2obcUHZ7xwUBBjph8+PGtmW/2lYhbLizWtG7nTeYht36WfOslixQF9D/uSIzhZgGMfQ=="
     },
+    "leaflet.markercluster": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/leaflet.markercluster/-/leaflet.markercluster-1.5.3.tgz",
+      "integrity": "sha512-vPTw/Bndq7eQHjLBVlWpnGeLa3t+3zGiuM7fJwCkiMFq+nmRuG3RI3f7f4N4TDX7T4NpbAXpR2+NTRSEGfCSeA==",
+      "requires": {}
+    },
     "leven": {
       "version": "3.1.0",
       "resolved": "https://packages.atlassian.com/api/npm/npm-remote/leven/-/leven-3.1.0.tgz",
@@ -30725,6 +30754,14 @@
       "integrity": "sha512-9d8T7hzYrQA5GLe3vn0qtRLJzQKgjr080NKa45yArGwuSl1nH/6aK9gp7DeYdktpdO1vKGSUTGW5AsUS064X0A==",
       "requires": {
         "@react-leaflet/core": "^2.1.0"
+      }
+    },
+    "react-leaflet-cluster": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet-cluster/-/react-leaflet-cluster-2.1.0.tgz",
+      "integrity": "sha512-16X7XQpRThQFC4PH4OpXHimGg19ouWmjxjtpxOeBKpvERSvIRqTx7fvhTwkEPNMFTQ8zTfddz6fRTUmUEQul7g==",
+      "requires": {
+        "leaflet.markercluster": "^1.5.3"
       }
     },
     "react-popper": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-leaflet": "^4.2.0",
+    "react-leaflet-cluster": "^2.1.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "^5.0.1",
     "semantic-ui-react": "^2.1.4",

--- a/src/components/FilterBox.jsx
+++ b/src/components/FilterBox.jsx
@@ -1,12 +1,10 @@
-import React, {useEffect, useState} from 'react'
-import { ClickAwayListener, Stack, Typography } from '@mui/material'
-import { Button } from '@mui/material'
-import { Grid } from '@mui/material'
 import CheckIcon from '@mui/icons-material/Check';
-import HomeIcon from '@mui/icons-material/Home';
-import { borderRadius } from '@mui/system';
-import Checkbox from '@mui/material/Checkbox';
 import FilterAltIcon from '@mui/icons-material/FilterAlt';
+import HomeIcon from '@mui/icons-material/Home';
+import { Button, ClickAwayListener, Grid, Stack, Typography } from '@mui/material';
+import Checkbox from '@mui/material/Checkbox';
+import { borderRadius } from '@mui/system';
+import React, { useEffect, useState } from 'react';
 
 
 const FilterBox = ({showOnlyVerified, handleVerificationChange}) => {
@@ -28,7 +26,7 @@ const FilterBox = ({showOnlyVerified, handleVerificationChange}) => {
               sx={{
                 p: 1,
                 marginLeft: "2px",
-                top: "210px",
+                top: "250px",
                 position: "fixed",
                 zIndex: "9999",
               }}

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -24,9 +24,9 @@ const Map = ({sites, center, addCommentToSite, whenMapReady}) => {
       <MarkerClusterGroup
         chunkedLoading
         showCoverageOnHover={true}
-        maxClusterRadius={100}
+        maxClusterRadius={80}
         spiderfyOnMaxZoom={true}
-        disableClusteringAtZoom={12}
+        disableClusteringAtZoom={14}
         removeOutsideVisibleBounds
       >
         {

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -1,6 +1,7 @@
-import React, {useEffect, useState} from 'react'
-import {MapContainer, Marker, Popup, TileLayer, Tooltip, useMap, useMapEvent} from "react-leaflet";
-import {Button, Comment, Form, Header, TextArea} from 'semantic-ui-react'
+import React, { useEffect, useState } from 'react';
+import { MapContainer, Marker, Popup, TileLayer, Tooltip, useMap, useMapEvent } from "react-leaflet";
+import MarkerClusterGroup from 'react-leaflet-cluster';
+import { Button, Comment, Form, Header, TextArea } from 'semantic-ui-react';
 import FilterBox from "./FilterBox";
 import SiteMarker from "./SiteMarker";
 
@@ -42,23 +43,32 @@ const Map = ({handleCreateSiteDialogOpen, sites, center, addCommentToSite,whenMa
         attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
       />
-      {
-        sites.filter(
-          (site) => {
-            let valid_sites = site.location && site.location.latitude && site.location.longitude
-            
-            // Apply filters
-            if (showOnlyVerified) {
-              valid_sites = valid_sites && site.verified
-            }
-            return valid_sites
-          })
-          .map(site => {
-            return (
-              <SiteMarker site={site} addCommentToSite={addCommentToSite}></SiteMarker>
-            )
-          })
-      }
+      <MarkerClusterGroup
+        chunkedLoading
+        showCoverageOnHover={true}
+        maxClusterRadius={100}
+        spiderfyOnMaxZoom={true}
+        disableClusteringAtZoom={12}
+        removeOutsideVisibleBounds
+      >
+        {
+          sites.filter(
+            (site) => {
+              let valid_sites = site.location && site.location.latitude && site.location.longitude
+              
+              // Apply filters
+              if (showOnlyVerified) {
+                valid_sites = valid_sites && site.verified
+              }
+              return valid_sites
+            })
+            .map(site => {
+              return (
+                <SiteMarker site={site} addCommentToSite={addCommentToSite}></SiteMarker>
+              )
+            })
+        }
+      </MarkerClusterGroup>
       <MyComponent></MyComponent>
     </MapContainer>
   );


### PR DESCRIPTION
**Changes**

- Added the react-leaflet-clustering library as dependency.
- Fixed the positioning of the FilterBox component for mobile devices. FilterBox used to stack on top of the Zoom icons, it is moved to a lower position in the screen.
- Added clustering support for markers. Clustering does not occur after 12+ zoom levels. This might increase the performance in the future, when markers from different cities will be added. With clustering, only the needed markers will be rendered instead of all of the markers.

**In the future**, maybe clustering can be added as a filtering option. Although enabling it by default might be more helpful.

The clustering looks like the follows for zoom level 11:
![zoom-11](https://user-images.githubusercontent.com/53442050/218261510-e5a22048-d889-49e2-b7b0-450f0a1a2dbb.png)

And this is how it looks for zoom level 12 and upwards:
![zoom-12](https://user-images.githubusercontent.com/53442050/218261558-d87761dc-1d0e-4810-bacd-f3d2cf498a4c.png)

