### PR TITLE
Simpler onboarding dialog

### DIFF
--- a/src/components/MainPage/MainPage.jsx
+++ b/src/components/MainPage/MainPage.jsx
@@ -45,9 +45,9 @@ const MainPage = () => {
 
   const handleSetSelectedCity = (newCity) => {
     if (newCity) {
-      window.history.pushState(null, '', `?city=${newCity.label}`)
       setSelectedCity(newCity)
       localStorage.setItem("selectedCity", JSON.stringify(newCity))
+      window.history.pushState(null, '', `?city=${newCity.label}`)
     }
   }
  
@@ -98,13 +98,15 @@ const MainPage = () => {
       else {
         setErrMsg(`${newValue.label} şehrinin koordinatlarında bir sorun var.`)
       }
-
+      
       // Remove markers first to overcome issues regarding the URL queries. Otherwise, the default
       // behavior during the removal of the marker results in the URL being not updated
+      console.log(`here`)
+      console.log(newValue)
       sites.forEach((s) => s.markerRef.remove())
 
       //
-      fetchSitesOfSelectedCity(newValue)
+      await fetchSitesOfSelectedCity(newValue)
       handleSetSelectedCity(newValue);
     }
   };
@@ -351,7 +353,7 @@ const MainPage = () => {
         handleClose={handleOnboardingDialogClose}
         handleShowMeClosestSite={handleShowMeClosestSite}
         showClosestSiteButton={true}
-        handleSelectCity={handleSetSelectedCity}
+        handleSelectCity={handleSelectCity}
         selectedCity={selectedCity}
       />
       {/*Disabled site creation dialog, only feed the system from spreadsheets*/}

--- a/src/components/OnboardingDialog/OnboardingDialog.jsx
+++ b/src/components/OnboardingDialog/OnboardingDialog.jsx
@@ -11,7 +11,6 @@ import ClosestHelpSiteButton from '../ClosestHelpSiteButton';
 import "./OnboardingDialog.css";
 
 const OnboardingDialog = ({open, handleClose, setOnboardingDialogOpen, showClosestSiteButton, handleSelectCity, selectedCity, sites, mapRef}) => {
-
   return (
     <Dialog disableEscapeKeyDown={selectedCity != null} open={open} onClose={handleClose}>
       <DialogTitle>
@@ -24,6 +23,7 @@ const OnboardingDialog = ({open, handleClose, setOnboardingDialogOpen, showClose
           renderInput={(params) => <TextField {...params} label="Şehir"/>}
           onChange={(event, value) => {
             handleSelectCity(value);
+            console.log("Here")
           }}
           value={selectedCity}
       />}
@@ -31,18 +31,11 @@ const OnboardingDialog = ({open, handleClose, setOnboardingDialogOpen, showClose
       {showClosestSiteButton && selectedCity &&
         <Stack spacing={2}>
           <p>
-            Şehrinizdeki yardım alanlarıyla ilgili detayları haritada bulabilirsiniz. 
-            Daha detaylı bilgilere ulaşmak için konumların üzerine tıklayabilirsiniz. 
-            Eğer size en yakın yardım merkezini öğrenmek istiyorsanız lütfen aşağıdaki 
-            butonu kullanın.
+          Haritadaki veriler seçilen illerdeki yardım organizasyon gruplarının kullandıkları spreadsheetlerden 
+          güncellenmektedir. Bu organizasyonlardaki arkadaşlar ellerinden geldikçe çok güncelleme girmeye çalışsalar da
+           her lokasyon için her zaman güncel veri bulunmayabilir. Gitmeyi planladığınız alanın son güncellenme 
+           tarihini kontrol etmeyi unutmayın.
           </p>
-          <ClosestHelpSiteButton
-            sites={sites}
-            mapRef={mapRef}
-            callback={() => setOnboardingDialogOpen(false)}
-          >
-           Bana En Yakın Yardım Alanını Göster
-          </ClosestHelpSiteButton>
         </Stack>
       }
       </DialogContent>

--- a/src/hooks/useClosestSite.js
+++ b/src/hooks/useClosestSite.js
@@ -43,6 +43,7 @@ const useClosestSite = (sites) => {
 
     const calculateClosestSite = (pos) => {
         const { latitude, longitude } = pos.coords
+        console.log(sites)
         if (!sites || sites.length === 0) {
             setErrMsg("Yardım toplama noktaları henüz yüklenmedi.")
             setState("error")


### PR DESCRIPTION
User encounters too many dialogs on the initial launch. To have a simplistic approach, we should have the closest site button once, that is on the map.